### PR TITLE
perf: speed up popup dictionary lookup

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -4,7 +4,11 @@
 <head>
   <meta charset="utf-8">
   <title>划词词典</title>
-  <script src="popup.js"></script>
+  <link rel="preconnect" href="https://www.zdic.net" crossorigin>
+  <link rel="preconnect" href="https://cn.bing.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.zdic.net">
+  <link rel="dns-prefetch" href="https://cn.bing.com">
+  <script src="popup.js" defer></script>
 
   <style type="text/css">
     body {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -26,18 +26,16 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
     result = result.trim();
 
-    let url = "http://www.zdic.net/hans/" + result;
+    let url = "https://www.zdic.net/hans/" + encodeURIComponent(result);
     if (result.isEnglish()) {
-        url = "https://cn.bing.com/dict/search?mkt=zh-cn&q=" + result;
+        url = "https://cn.bing.com/dict/search?mkt=zh-cn&q=" + encodeURIComponent(result);
     }
     if (result.length === 0) {
-        url = "http://www.zdic.net/";
+        url = "https://www.zdic.net/";
     }
 
-    setTimeout(function () {
-        dictionaryFrame.src = url;
-        dictionaryFrame.addEventListener("load", function () {
-            indicator.textContent = "";
-        });
-    }, 10);
+    dictionaryFrame.addEventListener("load", function () {
+        indicator.textContent = "";
+    });
+    dictionaryFrame.src = url;
 });


### PR DESCRIPTION
- Use HTTPS for zdic.net to avoid the 301 redirect that adds a full extra roundtrip on every lookup.
- Add preconnect/dns-prefetch hints for zdic.net and cn.bing.com so DNS, TCP, and TLS warm up in parallel with selection retrieval instead of starting only when the iframe sets its src.
- Drop the unconditional 10ms setTimeout before assigning the iframe src; it served no purpose and just delayed every query.
- Attach the iframe load listener before setting src so the indicator is reliably cleared.
- Defer popup.js and encodeURIComponent the query so selections containing spaces or special characters work correctly.